### PR TITLE
Add support for exploding graphics files

### DIFF
--- a/src/bin/monokakido-explode.rs
+++ b/src/bin/monokakido-explode.rs
@@ -33,6 +33,7 @@ fn explode() -> Result<(), Error> {
 
     let pages_dir = out_dir(&dict) + "pages/";
     let audio_dir = out_dir(&dict) + "audio/";
+    let graphics_dir = out_dir(&dict) + "graphics/";
 
     create_dir_all(&pages_dir)?;
     let mut path = String::from(&pages_dir);
@@ -53,6 +54,18 @@ fn explode() -> Result<(), Error> {
             let mut file = File::create(&path)?;
             path.truncate(audio_dir.len());
             file.write_all(audio)?;
+        }
+    }
+
+    if let Some(graphics) = &mut dict.graphics {
+        create_dir_all(&graphics_dir)?;
+        let mut path = String::from(&graphics_dir);
+        for idx in graphics.idx_iter()? {
+            let (id, graphics) = graphics.get_by_idx(idx)?;
+            write!(&mut path, "{id}")?;
+            let mut file = File::create(&path)?;
+            path.truncate(graphics_dir.len());
+            file.write_all(graphics)?;
         }
     }
 

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -136,8 +136,8 @@ impl MonokakidoDict {
             contents_dir: contents.dir,
         };
         let pages = Pages::new(&paths)?;
-        let audio = Media::new(&paths)?;
-        let graphics = Media::new(&paths)?;
+        let audio = Media::new(&paths, "audio")?;
+        let graphics = Media::new(&paths, "graphics")?;
         let keys = Keys::new(&paths)?;
 
         Ok(MonokakidoDict {

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -5,12 +5,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{audio::Audio, key::Keys, pages::Pages, Error};
+use crate::{media::Media, key::Keys, pages::Pages, Error};
 
 pub struct MonokakidoDict {
     paths: Paths,
     pub pages: Pages,
-    pub audio: Option<Audio>,
+    pub audio: Option<Media>,
+    pub graphics: Option<Media>,
     pub keys: Keys,
 }
 
@@ -135,13 +136,15 @@ impl MonokakidoDict {
             contents_dir: contents.dir,
         };
         let pages = Pages::new(&paths)?;
-        let audio = Audio::new(&paths)?;
+        let audio = Media::new(&paths)?;
+        let graphics = Media::new(&paths)?;
         let keys = Keys::new(&paths)?;
 
         Ok(MonokakidoDict {
             paths,
             pages,
             audio,
+            graphics,
             keys,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod abi_utils;
-mod audio;
+mod media;
 mod dict;
 mod error;
 mod key;
@@ -7,7 +7,7 @@ mod pages;
 mod resource;
 mod headline;
 
-pub use audio::Audio;
+pub use media::Media;
 pub use dict::MonokakidoDict;
 pub use error::Error;
 pub use key::{KeyIndex, Keys, PageItemId};

--- a/src/media.rs
+++ b/src/media.rs
@@ -8,22 +8,22 @@ use crate::{
 
 const RSC_NAME: &str = "audio";
 
-pub struct Audio {
+pub struct Media {
     path: PathBuf,
-    res: Option<AudioResource>,
+    res: Option<MediaResource>,
 }
 
-enum AudioResource {
+enum MediaResource {
     Rsc(Rsc),
     Nrsc(Nrsc),
 }
 
-impl Audio {
+impl Media {
     pub fn new(paths: &Paths) -> Result<Option<Self>, Error> {
         let mut path = paths.contents_path();
         path.push(RSC_NAME);
         Ok(if path.exists() {
-            Some(Audio { path, res: None })
+            Some(Media { path, res: None })
         } else {
             None
         })
@@ -35,9 +35,9 @@ impl Audio {
             let nrsc_index_exists = self.path.exists();
             self.path.pop();
             self.res = Some(if nrsc_index_exists {
-                AudioResource::Nrsc(Nrsc::new(&self.path)?)
+                MediaResource::Nrsc(Nrsc::new(&self.path)?)
             } else {
-                AudioResource::Rsc(Rsc::new(&self.path, RSC_NAME)?)
+                MediaResource::Rsc(Rsc::new(&self.path, RSC_NAME)?)
             });
         }
         Ok(())
@@ -47,22 +47,22 @@ impl Audio {
         self.init()?;
         let Some(res) = self.res.as_mut() else { unreachable!() };
         match res {
-            AudioResource::Rsc(rsc) => rsc.get(id.parse::<u32>().map_err(|_| Error::InvalidIndex)?),
-            AudioResource::Nrsc(nrsc) => nrsc.get(id),
+            MediaResource::Rsc(rsc) => rsc.get(id.parse::<u32>().map_err(|_| Error::InvalidIndex)?),
+            MediaResource::Nrsc(nrsc) => nrsc.get(id),
         }
     }
 
-    pub fn get_by_idx(&mut self, idx: usize) -> Result<(AudioId, &[u8]), Error> {
+    pub fn get_by_idx(&mut self, idx: usize) -> Result<(MediaId, &[u8]), Error> {
         self.init()?;
         let Some(res) = self.res.as_mut() else { unreachable!() };
         Ok(match res {
-            AudioResource::Rsc(rsc) => {
+            MediaResource::Rsc(rsc) => {
                 let (id, page) = rsc.get_by_idx(idx)?;
-                (AudioId::Num(id), page)
+                (MediaId::Num(id), page)
             }
-            AudioResource::Nrsc(nrsc) => {
+            MediaResource::Nrsc(nrsc) => {
                 let (id, page) = nrsc.get_by_idx(idx)?;
-                (AudioId::Str(id), page)
+                (MediaId::Str(id), page)
             }
         })
     }
@@ -71,19 +71,19 @@ impl Audio {
         self.init()?;
         let Some(res) = self.res.as_ref() else { unreachable!() };
         Ok(0..match res {
-            AudioResource::Rsc(rsc) => rsc.len(),
-            AudioResource::Nrsc(nrsc) => nrsc.len(),
+            MediaResource::Rsc(rsc) => rsc.len(),
+            MediaResource::Nrsc(nrsc) => nrsc.len(),
         })
     }
 }
 
 #[derive(Debug)]
-pub enum AudioId<'a> {
+pub enum MediaId<'a> {
     Str(&'a str),
     Num(u32),
 }
 
-impl Display for AudioId<'_> {
+impl Display for MediaId<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Str(str) => f.write_str(str),

--- a/src/media.rs
+++ b/src/media.rs
@@ -6,11 +6,10 @@ use crate::{
     Error,
 };
 
-const RSC_NAME: &str = "audio";
-
 pub struct Media {
     path: PathBuf,
     res: Option<MediaResource>,
+    name: String,
 }
 
 enum MediaResource {
@@ -19,11 +18,11 @@ enum MediaResource {
 }
 
 impl Media {
-    pub fn new(paths: &Paths) -> Result<Option<Self>, Error> {
+    pub fn new(paths: &Paths, rsc_name: &str) -> Result<Option<Self>, Error> {
         let mut path = paths.contents_path();
-        path.push(RSC_NAME);
+        path.push(rsc_name);
         Ok(if path.exists() {
-            Some(Media { path, res: None })
+            Some(Media { path, res: None, name: rsc_name.to_string() })
         } else {
             None
         })
@@ -37,7 +36,7 @@ impl Media {
             self.res = Some(if nrsc_index_exists {
                 MediaResource::Nrsc(Nrsc::new(&self.path)?)
             } else {
-                MediaResource::Rsc(Rsc::new(&self.path, RSC_NAME)?)
+                MediaResource::Rsc(Rsc::new(&self.path, &self.name)?)
             });
         }
         Ok(())

--- a/src/media.rs
+++ b/src/media.rs
@@ -21,7 +21,13 @@ impl Media {
     pub fn new(paths: &Paths, rsc_name: &str) -> Result<Option<Self>, Error> {
         let mut path = paths.contents_path();
         path.push(rsc_name);
-        Ok(if path.exists() {
+        path.push("index.nidx");
+        let nrsc_index_exists = path.exists();
+        path.pop();
+        path.push("audio.map");
+        let rsc_index_exists = path.exists();
+        path.pop();
+        Ok(if nrsc_index_exists || rsc_index_exists {
             Some(Media { path, res: None, name: rsc_name.to_string() })
         } else {
             None


### PR DESCRIPTION
The `audio` module already worked with graphics files as well, so I just renamed it to `media`.

I've tested this with DAIJIRIN2, DAIJISEN2, and NDS, and it seems to work fine.